### PR TITLE
新規登録・更新・削除のテスト実装

### DIFF
--- a/src/main/java/com/example/demo/controller/DateCalculationController.java
+++ b/src/main/java/com/example/demo/controller/DateCalculationController.java
@@ -117,11 +117,8 @@ public class DateCalculationController {
     // top.htmlにて[更新]押下時にchange.htmlを表示
     @GetMapping("/change/id={id}")
     public String change(@PathVariable("id") int id, Model model, RedirectAttributes redirectAttributes) {
-//	System.out.println(dateCalculationService.getOne(id));
-
 	Optional<FormulaData> fd = dateCalculationService.getOne(id);
 	if (fd.isEmpty()) {
-	    System.out.println("値がnullです");
 	    redirectAttributes.addFlashAttribute("complete", "存在しないIDです。");
 	    return "redirect:/calculation/top";
 	}

--- a/src/main/java/com/example/demo/controller/DateCalculationController.java
+++ b/src/main/java/com/example/demo/controller/DateCalculationController.java
@@ -117,7 +117,7 @@ public class DateCalculationController {
     // top.htmlにて[更新]押下時にchange.htmlを表示
     @GetMapping("/change/id={id}")
     public String change(@PathVariable("id") int id, Model model, RedirectAttributes redirectAttributes) {
-	System.out.println(dateCalculationService.getOne(id));
+//	System.out.println(dateCalculationService.getOne(id));
 
 	Optional<FormulaData> fd = dateCalculationService.getOne(id);
 	if (fd.isEmpty()) {

--- a/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
+++ b/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -191,6 +192,59 @@ public class DateCalculationControllerTest {
 			.andExpect(view().name("redirect:/calculation/top"));
 
 	verify(dateCalculationService).insertOne(any());
+    }
+
+    @Test
+    void 更新ページをGETすると結果が200となり更新ページが返ること() throws Exception {
+	Optional<FormulaData> fd = Optional.of(new FormulaData(1, "年のみ", "最大値", 100, 0, 0));
+	doReturn(fd).when(dateCalculationService)
+			.getOne(1);
+	mockMvc.perform(get("/calculation/change/id={id}", "1"))
+			.andExpect(status().isOk())
+			.andExpect(model().attribute("formulaData", fd.get()))
+			.andExpect(view().name("calculation/change"));
+
+	verify(dateCalculationService).getOne(1);
+    }
+
+    @Test
+    void 存在しないIDにて更新ページをGETするとTOPページに遷移すること() throws Exception {
+	doReturn(Optional.empty()).when(dateCalculationService)
+			.getOne(999);
+	mockMvc.perform(get("/calculation/change/id={id}", "999"))
+			.andExpect(status().isFound())
+			.andExpect(view().name("redirect:/calculation/top"));
+
+	verify(dateCalculationService).getOne(999);
+    }
+
+    // 新規登録画面同様のバリデーションチェックが機能するか1パターン確認
+    @Test
+    void 更新ページで登録名がNULLの状態で次へ進むと例外情報が入った状態で画面が返ること() throws Exception {
+	mockMvc.perform(
+			post("/calculation/change-confirm").param("id", "1")
+					.param("detail", "最大値")
+					.param("year", "100")
+					.param("month", "0")
+					.param("day", "0"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("calculation/change"));
+    }
+
+    @Test
+    void 更新確認ページで更新処理に成功するとサービスで処理されてTOPページに遷移すること() throws Exception {
+	mockMvc.perform(
+			post("/calculation/change-complete").param("id", "1")
+					.param("name", "年のみ")
+					.param("detail", "最小値")
+					.param("year", "-100")
+					.param("month", "0")
+					.param("day", "0"))
+			.andExpect(status().isFound())
+			.andExpect(model().hasNoErrors())
+			.andExpect(view().name("redirect:/calculation/top"));
+
+	verify(dateCalculationService).updateOne(1, "年のみ", "最小値", -100, 0, 0);
     }
 
 }

--- a/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
+++ b/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
@@ -111,6 +111,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/new"));
     }
 
@@ -124,6 +125,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/new"));
     }
 
@@ -137,6 +139,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/new"));
     }
 
@@ -149,6 +152,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/new"));
     }
 
@@ -162,6 +166,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/new"));
     }
 
@@ -175,6 +180,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/new"));
     }
 
@@ -228,6 +234,7 @@ public class DateCalculationControllerTest {
 					.param("month", "0")
 					.param("day", "0"))
 			.andExpect(status().isOk())
+			.andExpect(model().hasErrors())
 			.andExpect(view().name("calculation/change"));
     }
 

--- a/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
+++ b/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
@@ -199,7 +199,7 @@ public class DateCalculationControllerTest {
 	Optional<FormulaData> fd = Optional.of(new FormulaData(1, "年のみ", "最大値", 100, 0, 0));
 	doReturn(fd).when(dateCalculationService)
 			.getOne(1);
-	mockMvc.perform(get("/calculation/change/id={id}", "1"))
+	mockMvc.perform(get("/calculation/change/id={id}", 1))
 			.andExpect(status().isOk())
 			.andExpect(model().attribute("formulaData", fd.get()))
 			.andExpect(view().name("calculation/change"));
@@ -245,6 +245,15 @@ public class DateCalculationControllerTest {
 			.andExpect(view().name("redirect:/calculation/top"));
 
 	verify(dateCalculationService).updateOne(1, "年のみ", "最小値", -100, 0, 0);
+    }
+
+    @Test
+    void TOPページで削除するとサービスで処理されてTOPページに遷移すること() throws Exception {
+	mockMvc.perform(post("/calculation/delete/id={id}", 1))
+			.andExpect(status().isFound())
+			.andExpect(view().name("redirect:/calculation/top"));
+
+	verify(dateCalculationService).deleteOne(any());
     }
 
 }

--- a/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
+++ b/src/test/java/com/example/demo/controller/DateCalculationControllerTest.java
@@ -104,8 +104,10 @@ public class DateCalculationControllerTest {
 
     @Test
     void 新規登録ページで登録名がNULLの状態で次へ進むと例外情報が入った状態で画面が返ること() throws Exception {
+	String str = null;
 	mockMvc.perform(
 			post("/calculation/new-confirm").param("id", "1")
+					.param("name", str)
 					.param("detail", "最大値")
 					.param("year", "100")
 					.param("month", "0")
@@ -145,9 +147,11 @@ public class DateCalculationControllerTest {
 
     @Test
     void 新規登録ページで説明がNULLの状態で次へ進むと例外情報が入った状態で画面が返ること() throws Exception {
+	String str = null;
 	mockMvc.perform(
 			post("/calculation/new-confirm").param("id", "1")
 					.param("name", "年のみ")
+					.param("detail", str)
 					.param("year", "100")
 					.param("month", "0")
 					.param("day", "0"))
@@ -227,8 +231,10 @@ public class DateCalculationControllerTest {
     // 新規登録画面同様のバリデーションチェックが機能するか1パターン確認
     @Test
     void 更新ページで登録名がNULLの状態で次へ進むと例外情報が入った状態で画面が返ること() throws Exception {
+	String str = null;
 	mockMvc.perform(
 			post("/calculation/change-confirm").param("id", "1")
+					.param("name", str)
 					.param("detail", "最大値")
 					.param("year", "100")
 					.param("month", "0")


### PR DESCRIPTION
お世話になっております。
TOP画面のレビュー結果を元に、新規登録画面・更新画面・削除メソッドのテストも実装致しました。
お手すきの際に、ご確認の程よろしくお願い致します。

[新規登録画面のテスト作成](https://github.com/shipo3/DateCalculation/commit/7c8b509d126a7eec6b505c1b59c28d458ec479d3)
└ ブランチ操作間違いがあった為、こちらはmainにマージ済となっております。

[更新画面のテスト実装](https://github.com/shipo3/DateCalculation/commit/0b6e68f5821c6598accb1cca9a26a7811c966b26)
└ バリデーションチェックをどこまでするか迷いましたが、新規登録で全パターン（登録名・説明に対して、NULL・空白・最大文字数＋１）を実施しましたので、更新画面のURLにしても機能するかの確認として1つのみ（登録名がNULLの場合）実施しています。

[削除メソッドのテスト実装](https://github.com/shipo3/DateCalculation/commit/c69c3bf7e550f2a6c3a768faaa2239ba5803a23c)